### PR TITLE
Fix for single ended int overflow

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -69,10 +69,10 @@ static void writeRegister(uint8_t i2cAddress, uint8_t reg, uint16_t value) {
 
 /**************************************************************************/
 /*!
-    @brief  Writes 16-bits to the specified destination register
+    @brief  Read 16-bits from the conversion register (ALWAYS signed, even in single-ended mode)
 */
 /**************************************************************************/
-static uint16_t readRegister(uint8_t i2cAddress, uint8_t reg) {
+static int16_t readRegister(uint8_t i2cAddress, uint8_t reg) {
   Wire.beginTransmission(i2cAddress);
   i2cwrite(ADS1015_REG_POINTER_CONVERT);
   Wire.endTransmission();
@@ -140,7 +140,7 @@ adsGain_t Adafruit_ADS1015::getGain()
     @brief  Gets a single-ended ADC reading from the specified channel
 */
 /**************************************************************************/
-uint16_t Adafruit_ADS1015::readADC_SingleEnded(uint8_t channel) {
+int16_t Adafruit_ADS1015::readADC_SingleEnded(uint8_t channel) {
   if (channel > 3)
   {
     return 0;

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -26,6 +26,9 @@
 
 #include <Wire.h>
 
+#ifndef _ADAFRUIT_ADS1X15_H
+#define _ADAFRUIT_ADS1X15_H
+
 /*=========================================================================
     I2C ADDRESS/BITS
     -----------------------------------------------------------------------*/
@@ -148,3 +151,5 @@ class Adafruit_ADS1115 : public Adafruit_ADS1015
 
  private:
 };
+
+#endif

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -129,7 +129,7 @@ protected:
  public:
   Adafruit_ADS1015(uint8_t i2cAddress = ADS1015_ADDRESS);
   void begin(void);
-  uint16_t  readADC_SingleEnded(uint8_t channel);
+  int16_t   readADC_SingleEnded(uint8_t channel);
   int16_t   readADC_Differential_0_1(void);
   int16_t   readADC_Differential_2_3(void);
   void      startComparator_SingleEnded(uint8_t channel, int16_t threshold);


### PR DESCRIPTION
The readADC_SingleEnded method returned a uint16_t, but this is not valid. The ADC conversion register can still contain a negative number if a single-ended input is pulled below 0V.

This is because the ADC is still performing a differential conversion.

The correct behaviour is for the library to always return a signed integer for any conversion.

This will limit the effective range of the single-ended conversion to 15 bits (0 to 32767) as described in the ADS1115 datasheet (page 26: SINGLE-ENDED INPUTS).

Currently, the conversion to a uint16_t will cause an underflow to 65536 or lower in these cases.

This pull request fixes this issue.

It also fixes the commenting as described in issue #7.
