### PR TITLE
Added support for window comparator mode

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -307,7 +307,6 @@ void Adafruit_ADS1015::startComparator_SingleEnded(uint8_t channel, int16_t thre
                     ADS1015_REG_CONFIG_CPOL_ACTVLOW | // Alert/Rdy active low   (default val)
                     ADS1015_REG_CONFIG_CMODE_TRAD   | // Traditional comparator (default val)
                     ADS1015_REG_CONFIG_DR_1600SPS   | // 1600 samples per second (default)
-                    ADS1015_REG_CONFIG_MODE_CONTIN  | // Continuous conversion mode
                     ADS1015_REG_CONFIG_MODE_CONTIN;   // Continuous conversion mode
 
   // Set PGA/voltage range
@@ -333,6 +332,58 @@ void Adafruit_ADS1015::startComparator_SingleEnded(uint8_t channel, int16_t thre
   // Set the high threshold register
   // Shift 12-bit results left 4 bits for the ADS1015
   writeRegister(m_i2cAddress, ADS1015_REG_POINTER_HITHRESH, threshold << m_bitShift);
+
+  // Write config register to the ADC
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_CONFIG, config);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets up the comparator to operate in window mode, causing the
+            ALERT/RDY pin to assert (go from high to low) when the ADC
+            value exceeds the specified high threshold or when the ADC
+            value falls below the specified low threshold.
+
+            This will also set the ADC in continuous conversion mode.
+*/
+/**************************************************************************/
+void Adafruit_ADS1015::startComparator_SingleEnded(uint8_t channel, int16_t lo_threshold, int16_t hi_threshold)
+{
+  // Start with default values
+  uint16_t config = ADS1015_REG_CONFIG_CQUE_1CONV   | // Comparator enabled and asserts on 1 match
+                    ADS1015_REG_CONFIG_CLAT_LATCH   | // Latching mode
+                    ADS1015_REG_CONFIG_CPOL_ACTVLOW | // Alert/Rdy active low   (default val)
+                    ADS1015_REG_CONFIG_CMODE_WINDOW | // Window comparator
+                    ADS1015_REG_CONFIG_DR_1600SPS   | // 1600 samples per second (default)
+                    ADS1015_REG_CONFIG_MODE_CONTIN;   // Continuous conversion mode
+
+  // Set PGA/voltage range
+  config |= m_gain;
+                    
+  // Set single-ended input channel
+  switch (channel)
+  {
+    case (0):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_0;
+      break;
+    case (1):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_1;
+      break;
+    case (2):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_2;
+      break;
+    case (3):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_3;
+      break;
+  }
+
+  // Set the low threshold register
+  // Shift 12-bit results left 4 bits for the ADS1015
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_LOWTHRESH, lo_threshold << m_bitShift);
+
+  // Set the high threshold register
+  // Shift 12-bit results left 4 bits for the ADS1015
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_HITHRESH, hi_threshold << m_bitShift);
 
   // Write config register to the ADC
   writeRegister(m_i2cAddress, ADS1015_REG_POINTER_CONFIG, config);

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -133,6 +133,7 @@ protected:
   int16_t   readADC_Differential_0_1(void);
   int16_t   readADC_Differential_2_3(void);
   void      startComparator_SingleEnded(uint8_t channel, int16_t threshold);
+  void      startComparator_SingleEnded(uint8_t channel, int16_t lo_threshold, int16_t hi_threshold);
   int16_t   getLastConversionResults();
   void      setGain(adsGain_t gain);
   adsGain_t getGain(void);


### PR DESCRIPTION
Currently, the library only supports the **traditional** comparator mode through the function,

`void      startComparator_SingleEnded(uint8_t channel, int16_t threshold)`

This pull request adds support for the **window** comparator mode via the addition of the following overload function,

`void      startComparator_SingleEnded(uint8_t channel, int16_t lo_threshold, int16_t hi_threshold)`

This new function is almost identical, differing only in the addition of the low threshold and in the comparator mode selected.

The addition follows the window comparator mode specifications outlined in the datasheets (page 15 of the [ADS1115 datasheet](https://cdn-shop.adafruit.com/datasheets/ads1115.pdf) and page 12 of the [ADS1015 datasheet](https://cdn-shop.adafruit.com/datasheets/ads1015.pdf)).
