### PR TITLE
Added Teensy i2c_t3 library support

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -24,7 +24,13 @@
  #include "WProgram.h"
 #endif
 
-#include <Wire.h>
+// I2C library
+// Teensy 3.1, 3.2, LC
+#if defined(__MK20DX256__) || defined(__MKL26Z64__)
+  #include <i2c_t3.h>
+#else //For other Arduino
+  #include <Wire.h>
+#endif
 
 #include "Adafruit_ADS1015.h"
 

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -24,7 +24,13 @@
  #include "WProgram.h"
 #endif
 
-#include <Wire.h>
+// I2C library
+// Teensy 3.1, 3.2, LC
+#if defined(__MK20DX256__) || defined(__MKL26Z64__)
+  #include <i2c_t3.h>
+#else //For other Arduino
+  #include <Wire.h>
+#endif
 
 /*=========================================================================
     I2C ADDRESS/BITS


### PR DESCRIPTION
Dear Adafruit,

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  

Added #if statements in the beginning of Adafruit_ADS1015.cpp and Adafruit_ADS1015.h, to select whether to use Arduino default Wire library or i2c_t3 library if board hardware is Teensy 3.1,3.2,LC. 
( i2c_t3 is an Enhanced I2C library for Teensy 3.x & LC devices, which has better performance due to Teensy is not using AVR as MCU.)

- **Describe any known limitations with your change.** 

No. This change will not affect other Arduino boards.

- **Please run any tests or examples that can exercise your modified code.**  

Yes, tested on Uno, and Teensy 3.2,LC.

Thanks! 
LLL