### PR TITLE
Add alert pin support

### DIFF
--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -125,9 +125,10 @@ protected:
    uint8_t   m_conversionDelay;
    uint8_t   m_bitShift;
    adsGain_t m_gain;
+   int8_t    m_alertPin;
 
  public:
-  Adafruit_ADS1015(uint8_t i2cAddress = ADS1015_ADDRESS);
+   Adafruit_ADS1015(uint8_t i2cAddress = ADS1015_ADDRESS, int8_t alertPin = -1);
   void begin(void);
   uint16_t  readADC_SingleEnded(uint8_t channel);
   int16_t   readADC_Differential_0_1(void);
@@ -144,7 +145,8 @@ protected:
 class Adafruit_ADS1115 : public Adafruit_ADS1015
 {
  public:
-  Adafruit_ADS1115(uint8_t i2cAddress = ADS1015_ADDRESS);
+	Adafruit_ADS1115(uint8_t i2cAddress = ADS1015_ADDRESS,
+			 int8_t alertPin = -1);
 
  private:
 };


### PR DESCRIPTION
Scope of the change:
This change allows the user to specify the arduino pin connected to the alert pin on the sensor. This permits a faster sampling, as the hardcoded waiting timeout in the code can be skipped if the alert pin notifies. The feature is optional, as the pin is provided as an optional parameter in the constructor of the class object.

Limitations of the change:
None that I can think of

After testing it on my setup, I was able to move close to the specified 860 SPS as per the datasheet.

Thanks a lot!