### PR TITLE
ADS_1015 Future bug fix - use the passed in parameter

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -74,7 +74,7 @@ static void writeRegister(uint8_t i2cAddress, uint8_t reg, uint16_t value) {
 /**************************************************************************/
 static uint16_t readRegister(uint8_t i2cAddress, uint8_t reg) {
   Wire.beginTransmission(i2cAddress);
-  i2cwrite(ADS1015_REG_POINTER_CONVERT);
+  i2cwrite(reg);
   Wire.endTransmission();
   Wire.requestFrom(i2cAddress, (uint8_t)2);
   return ((i2cread() << 8) | i2cread());  


### PR DESCRIPTION
the constant being replaced was the constant passed in anyway
no functional change here, but it does save from future unexpected errors

example, the calling line looks like this:

`return readRegister(m_i2cAddress, ADS1015_REG_POINTER_CONVERT) >> m_bitShift;`