### PR TITLE
Window Comparator Mode

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -18,6 +18,7 @@
     v1.0 - First release
     v1.1  - Added ADS1115 support - W. Earl
     v1.2  - Added window comparitor support - B. Harville
+            https://github.com/PotatoX/Adafruit_ADS1X15
 */
 /**************************************************************************/
 #if ARDUINO >= 100

--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -340,6 +340,61 @@ void Adafruit_ADS1015::startComparator_SingleEnded(uint8_t channel, int16_t thre
 
 /**************************************************************************/
 /*!
+    @brief  Sets up the comparator to operate in window mode, causing the
+            ALERT/RDY pin to assert (go from high to low) when the ADC
+            value exceeds the specified threshold.
+
+            This will also set the ADC in continuous conversion mode.
+*/
+/**************************************************************************/
+void Adafruit_ADS1015::startComparator_DoubleEnded(uint8_t channel, int16_t highThreshold, int16_t lowThreshold)
+{
+  // Start with default values
+  uint16_t config = ADS1015_REG_CONFIG_CQUE_1CONV   | // Comparator enabled and asserts on 1 match
+                    ADS1015_REG_CONFIG_CLAT_LATCH   | // Latching mode
+                    ADS1015_REG_CONFIG_CPOL_ACTVLOW | // Alert/Rdy active low   (default val)
+                    ADS1015_REG_CONFIG_CMODE_WINDOW | // Traditional comparator (default val)
+                    ADS1015_REG_CONFIG_DR_1600SPS   | // 1600 samples per second (default)
+                    ADS1015_REG_CONFIG_MODE_CONTIN  | // Continuous conversion mode
+                    ADS1015_REG_CONFIG_MODE_CONTIN;   // Continuous conversion mode
+
+  // Set PGA/voltage range
+  config |= m_gain;
+                    
+  // Set single-ended input channel
+  switch (channel)
+  {
+    case (0):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_0;
+      break;
+    case (1):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_1;
+      break;
+    case (2):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_2;
+      break;
+    case (3):
+      config |= ADS1015_REG_CONFIG_MUX_SINGLE_3;
+      break;
+  }
+
+  // Set the high threshold register
+  // Shift 12-bit results left 4 bits for the ADS1015
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_HITHRESH, highThreshold << m_bitShift);
+
+  // Write config register to the ADC
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_CONFIG, config);
+  
+  // Set the low threshold register
+  // Shift 12-bit results left 4 bits for the ADS1015
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_LOWTHRESH, lowThreshold << m_bitShift);
+
+  // Write config register to the ADC
+  writeRegister(m_i2cAddress, ADS1015_REG_POINTER_CONFIG, config);
+}
+
+/**************************************************************************/
+/*!
     @brief  In order to clear the comparator, we need to read the
             conversion results.  This function reads the last conversion
             results without changing the config value.

--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*!
     @file     Adafruit_ADS1015.cpp
-    @author   K.Townsend (Adafruit Industries)
+    @author   K.Townsend (Adafruit Industries), B. Harville
     @license  BSD (see license.txt)
 
     Driver for the ADS1015/ADS1115 ADC
@@ -16,6 +16,7 @@
     @section  HISTORY
 
     v1.0 - First release
+    v1.1 - Added window comparitor support
 */
 /**************************************************************************/
 #if ARDUINO >= 100

--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*!
     @file     Adafruit_ADS1015.cpp
-    @author   K.Townsend (Adafruit Industries), B. Harville
+    @author   K.Townsend (Adafruit Industries)
     @license  BSD (see license.txt)
 
     Driver for the ADS1015/ADS1115 ADC
@@ -16,7 +16,8 @@
     @section  HISTORY
 
     v1.0 - First release
-    v1.1 - Added window comparitor support
+    v1.1  - Added ADS1115 support - W. Earl
+    v1.2  - Added window comparitor support - B. Harville
 */
 /**************************************************************************/
 #if ARDUINO >= 100

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -15,6 +15,7 @@
 
     v1.0  - First release
     v1.1  - Added ADS1115 support - W. Earl
+    v1.2  - Added window comparitor support - B. Harville
 */
 /**************************************************************************/
 
@@ -133,6 +134,7 @@ protected:
   int16_t   readADC_Differential_0_1(void);
   int16_t   readADC_Differential_2_3(void);
   void      startComparator_SingleEnded(uint8_t channel, int16_t threshold);
+  void      startComparator_DoubleEnded(uint8_t channel, int16_t highThreshold, int16_t lowThreshold);
   int16_t   getLastConversionResults();
   void      setGain(adsGain_t gain);
   adsGain_t getGain(void);

--- a/Adafruit_ADS1015.h
+++ b/Adafruit_ADS1015.h
@@ -16,6 +16,7 @@
     v1.0  - First release
     v1.1  - Added ADS1115 support - W. Earl
     v1.2  - Added window comparitor support - B. Harville
+            https://github.com/PotatoX/Adafruit_ADS1X15
 */
 /**************************************************************************/
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ STM32F2            |             |             |     X       |
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
 
 <!-- END COMPATIBILITY TABLE -->
+
+Updates:
+========
+11/24/2017 - Added functionality for a window (double ended) comparitor mode

--- a/examples/window_comparator/window_comparator
+++ b/examples/window_comparator/window_comparator
@@ -1,0 +1,45 @@
+#include <Wire.h>
+#include <Adafruit_ADS1015.h>
+
+// Adafruit_ADS1115 ads;  /* Use this for the 16-bit version */
+Adafruit_ADS1015 ads;     /* Use thi for the 12-bit version */
+
+void setup(void) 
+{
+  Serial.begin(9600);
+  Serial.println("Hello!");
+  
+  Serial.println("Double-ended readings from AIN0 with >3.0V or <1.0V comparator");
+  Serial.println("ADC Range: +/- 6.144V (1 bit = 3mV/ADS1015, 0.1875mV/ADS1115)");
+  Serial.println("Comparator High Threshold: 1000 (3.000V)");
+  Serial.println("Comparator Low Threshold: 333 (1.000V)");
+  
+  // The ADC input range (or gain) can be changed via the following
+  // functions, but be careful never to exceed VDD +0.3V max, or to
+  // exceed the upper and lower limits if you adjust the input range!
+  // Setting these values incorrectly may destroy your ADC!
+  //                                                                ADS1015  ADS1115
+  //                                                                -------  -------
+  // ads.setGain(GAIN_TWOTHIRDS);  // 2/3x gain +/- 6.144V  1 bit = 3mV      0.1875mV (default)
+  // ads.setGain(GAIN_ONE);        // 1x gain   +/- 4.096V  1 bit = 2mV      0.125mV
+  // ads.setGain(GAIN_TWO);        // 2x gain   +/- 2.048V  1 bit = 1mV      0.0625mV
+  // ads.setGain(GAIN_FOUR);       // 4x gain   +/- 1.024V  1 bit = 0.5mV    0.03125mV
+  // ads.setGain(GAIN_EIGHT);      // 8x gain   +/- 0.512V  1 bit = 0.25mV   0.015625mV
+  // ads.setGain(GAIN_SIXTEEN);    // 16x gain  +/- 0.256V  1 bit = 0.125mV  0.0078125mV
+  
+  ads.begin();
+  
+  // Setup 3V high and 1V low comparator on channel 0
+  ads.startComparator_SingleEnded(0, 1000, 333);
+}
+
+void loop(void) 
+{
+  int16_t adc0;
+
+  // Comparator will only de-assert after a read
+  adc0 = ads.getLastConversionResults();
+  Serial.print("AIN0: "); Serial.println(adc0);
+  
+  delay(100);
+}


### PR DESCRIPTION
Change:
Added new function to allow for window comparator mode; the base was already present in the library, just needed a new method. Modified both source files and added an example.

Limitations:
No known limitations

Example:
Added basic window_comparator example to demonstrate new functionality
