### PR TITLE
Fix hardcoded reg addr in readRegister

### DIFF
--- a/Adafruit_ADS1015.cpp
+++ b/Adafruit_ADS1015.cpp
@@ -74,7 +74,7 @@ static void writeRegister(uint8_t i2cAddress, uint8_t reg, uint16_t value) {
 /**************************************************************************/
 static uint16_t readRegister(uint8_t i2cAddress, uint8_t reg) {
   Wire.beginTransmission(i2cAddress);
-  i2cwrite(ADS1015_REG_POINTER_CONVERT);
+  i2cwrite(reg);
   Wire.endTransmission();
   Wire.requestFrom(i2cAddress, (uint8_t)2);
   return ((i2cread() << 8) | i2cread());  


### PR DESCRIPTION
Yo. Added minor fix in readRegister function. This fix doesn't break any platform, just makes code more clear and predictable. Tested with Mega256 board.

Cheers,
Taras.