### PR TITLE
Add volts and other tweaks

### DIFF
--- a/Adafruit_ADS1X15.h
+++ b/Adafruit_ADS1X15.h
@@ -148,11 +148,12 @@ protected:
 
 public:
   void begin(uint8_t i2c_addr = ADS1X15_ADDRESS, TwoWire *wire = &Wire);
-  uint16_t readADC_SingleEnded(uint8_t channel);
+  int16_t readADC_SingleEnded(uint8_t channel);
   int16_t readADC_Differential_0_1();
   int16_t readADC_Differential_2_3();
   void startComparator_SingleEnded(uint8_t channel, int16_t threshold);
   int16_t getLastConversionResults();
+  float computeVolts(int16_t counts);
   void setGain(adsGain_t gain);
   adsGain_t getGain();
   void setDataRate(uint16_t rate);

--- a/examples/singleended/singleended.ino
+++ b/examples/singleended/singleended.ino
@@ -1,6 +1,6 @@
 #include <Adafruit_ADS1X15.h>
 
-// Adafruit_ADS1115 ads;  /* Use this for the 16-bit version */
+//Adafruit_ADS1115 ads;  /* Use this for the 16-bit version */
 Adafruit_ADS1015 ads;     /* Use this for the 12-bit version */
 
 void setup(void) 
@@ -30,16 +30,23 @@ void setup(void)
 void loop(void) 
 {
   int16_t adc0, adc1, adc2, adc3;
+  float volts0, volts1, volts2, volts3;
 
   adc0 = ads.readADC_SingleEnded(0);
   adc1 = ads.readADC_SingleEnded(1);
   adc2 = ads.readADC_SingleEnded(2);
   adc3 = ads.readADC_SingleEnded(3);
-  Serial.print("AIN0: "); Serial.println(adc0);
-  Serial.print("AIN1: "); Serial.println(adc1);
-  Serial.print("AIN2: "); Serial.println(adc2);
-  Serial.print("AIN3: "); Serial.println(adc3);
-  Serial.println(" ");
-  
+
+  volts0 = ads.computeVolts(adc0);
+  volts1 = ads.computeVolts(adc1);
+  volts2 = ads.computeVolts(adc2);
+  volts3 = ads.computeVolts(adc3);
+
+  Serial.println("-----------------------------------------------------------");
+  Serial.print("AIN0: "); Serial.print(adc0); Serial.print("  "); Serial.print(volts0); Serial.println("V");
+  Serial.print("AIN1: "); Serial.print(adc1); Serial.print("  "); Serial.print(volts1); Serial.println("V");
+  Serial.print("AIN2: "); Serial.print(adc2); Serial.print("  "); Serial.print(volts2); Serial.println("V");
+  Serial.print("AIN3: "); Serial.print(adc3); Serial.print("  "); Serial.print(volts3); Serial.println("V");
+
   delay(1000);
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,5 +6,8 @@ readADC_Differential_0_1	KEYWORD2
 readADC_Differential_2_3	KEYWORD2
 startComparator_SingleEnded	KEYWORD2
 getLastConversionResults	KEYWORD2
+computeVolts	KEYWORD2
 setGain	KEYWORD2
 getGain	KEYWORD2
+setDataRate	KEYWORD2
+getDataRate	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit ADS1X15
-version=2.0.1
+version=2.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for ADS1015/1115 ADCs.


### PR DESCRIPTION
The main thing here is providing a new function to convert counts to volts. Example updated to show usage. Not sure what's less clunky? This PR, which requires making two calls (one to read, one to convert) OR adding new "volts" versions of existing raw ADC read functions, like `readADC_SingeEnded_Volts` or some such. Could also be a parameter maybe? `readADC_SingleEnded(uint8_t channel, bool volts=False);`

Another minor but (possibly) significant tweak is changing the return type of `readADC_SingleEnded` from `uint16_t` to `int16_t`. The use of `uint16_t` has been the source of lots of confusion and issue generation. It worked fine, not really an issue, but technically, all the register values are signed:
![image](https://user-images.githubusercontent.com/8755041/112670670-6d5e6d00-8e1e-11eb-84aa-827f69e0c889.png)
even if generating a negative value is not possible for the current arrangement. Using `int16_t` also works, and I'm not seeing any reason not to just use that.