### PR TITLE
added parentheses in conversionComplete request

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -365,7 +365,7 @@ float Adafruit_ADS1X15::computeVolts(int16_t counts) {
 */
 /**************************************************************************/
 bool Adafruit_ADS1X15::conversionComplete() {
-  return readRegister(ADS1X15_REG_POINTER_CONFIG) & 0x8000 != 0;
+  return (readRegister(ADS1X15_REG_POINTER_CONFIG) & 0x8000) != 0;
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Without those parentheses the associativity does not fit to the expected behavior, at least in my case. I got the same known issue with the same value over all channels (#46).