### PR TITLE
Return bool for begin()

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -58,11 +58,13 @@ Adafruit_ADS1115::Adafruit_ADS1115() {
 
     @param i2c_addr I2C address of device
     @param wire I2C bus
+
+    @return true if successful, otherwise false
 */
 /**************************************************************************/
-void Adafruit_ADS1X15::begin(uint8_t i2c_addr, TwoWire *wire) {
+bool Adafruit_ADS1X15::begin(uint8_t i2c_addr, TwoWire *wire) {
   m_i2c_dev = new Adafruit_I2CDevice(i2c_addr, wire);
-  m_i2c_dev->begin();
+  return m_i2c_dev->begin();
 }
 
 /**************************************************************************/

--- a/Adafruit_ADS1X15.h
+++ b/Adafruit_ADS1X15.h
@@ -147,7 +147,7 @@ protected:
   uint16_t m_dataRate;           ///< Data rate
 
 public:
-  void begin(uint8_t i2c_addr = ADS1X15_ADDRESS, TwoWire *wire = &Wire);
+  bool begin(uint8_t i2c_addr = ADS1X15_ADDRESS, TwoWire *wire = &Wire);
   int16_t readADC_SingleEnded(uint8_t channel);
   int16_t readADC_Differential_0_1();
   int16_t readADC_Differential_2_3();


### PR DESCRIPTION
Simple change to return a boolean for `begin()` that is just the same as `i2cdev.begin()`.

This is for #66. But #64 may also be related. I dumped a code snippet in the issue thread for #64 that I tested but never PR'd, since there was no 100% sure way to solve the issue raised in #64. Can update this PR to include that as well?

