### PR TITLE
Update Adafruit_ADS1X15.cpp

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -367,7 +367,7 @@ float Adafruit_ADS1X15::computeVolts(int16_t counts) {
 */
 /**************************************************************************/
 bool Adafruit_ADS1X15::conversionComplete() {
-  return (readRegister(ADS1X15_REG_POINTER_CONFIG) & 0x8000) != 0;
+  return readRegister((ADS1X15_REG_POINTER_CONFIG) & 0x8000) != 0;
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Added parentheses since version 1.1 cause a memory pointer error on esp8266. Adding the parentheses in the way I propose solves the error.