### PR TITLE
Fix doc string and millivolts value in examples

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -276,7 +276,7 @@ int16_t Adafruit_ADS1X15::getLastConversionResults() {
 
 /**************************************************************************/
 /*!
-    @brief  Returns true if conversion is complete, false otherwise.
+    @brief  Compute volts for the given raw counts.
 
     @param counts the ADC reading in raw counts
 

--- a/examples/continuous/continuous.ino
+++ b/examples/continuous/continuous.ino
@@ -61,7 +61,7 @@ void loop(void)
 
   int16_t results = ads.getLastConversionResults();
 
-  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)); Serial.println("mV)");
+  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)/1000); Serial.println("mV)");
 
   new_data = false;
 

--- a/examples/nonblocking/nonblocking.ino
+++ b/examples/nonblocking/nonblocking.ino
@@ -42,7 +42,7 @@ void loop(void)
 
   int16_t results = ads.getLastConversionResults();
 
-  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)); Serial.println("mV)");
+  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)/1000); Serial.println("mV)");
 
   // Start another conversion.
   ads.startADCReading(ADS1X15_REG_CONFIG_MUX_DIFF_0_1, /*continuous=*/false);


### PR DESCRIPTION
Fixes #87 - add a divide by 1000 in examples so value is actually millivolts
Fixes #88 - updates docstring