### PR TITLE
Just make volts

### DIFF
--- a/examples/continuous/continuous.ino
+++ b/examples/continuous/continuous.ino
@@ -61,7 +61,7 @@ void loop(void)
 
   int16_t results = ads.getLastConversionResults();
 
-  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)/1000); Serial.println("mV)");
+  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)); Serial.println("V)");
 
   new_data = false;
 

--- a/examples/nonblocking/nonblocking.ino
+++ b/examples/nonblocking/nonblocking.ino
@@ -42,7 +42,7 @@ void loop(void)
 
   int16_t results = ads.getLastConversionResults();
 
-  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)/1000); Serial.println("mV)");
+  Serial.print("Differential: "); Serial.print(results); Serial.print("("); Serial.print(ads.computeVolts(results)); Serial.println("V)");
 
   // Start another conversion.
   ads.startADCReading(ADS1X15_REG_CONFIG_MUX_DIFF_0_1, /*continuous=*/false);


### PR DESCRIPTION
Oops, should have been `*1000` in #89 instead of `/1000`.

This PR removes that math and instead just reports the value as volts `V`. The ADC range is order of volts, so seems better approach.