### PR TITLE
Abstract and expose `getFsRange()`

### DIFF
--- a/Adafruit_ADS1X15.cpp
+++ b/Adafruit_ADS1X15.cpp
@@ -276,6 +276,40 @@ int16_t Adafruit_ADS1X15::getLastConversionResults() {
 
 /**************************************************************************/
 /*!
+    @brief  Return the current fs range for the configured gain
+
+    @return the fsRange for the configured gain, or zero.
+            Zero should not be possible thereby indicating error
+*/
+/**************************************************************************/
+float Adafruit_ADS1X15::getFsRange() {
+  // see data sheet Table 3
+  switch (m_gain) {
+  case GAIN_TWOTHIRDS:
+    return 6.144f;
+    break;
+  case GAIN_ONE:
+    return 4.096f;
+    break;
+  case GAIN_TWO:
+    return 2.048f;
+    break;
+  case GAIN_FOUR:
+    return 1.024f;
+    break;
+  case GAIN_EIGHT:
+    return 0.512f;
+    break;
+  case GAIN_SIXTEEN:
+    return 0.256f;
+    break;
+  default:
+    return 0.0f;
+  }
+}
+
+/**************************************************************************/
+/*!
     @brief  Compute volts for the given raw counts.
 
     @param counts the ADC reading in raw counts
@@ -284,31 +318,7 @@ int16_t Adafruit_ADS1X15::getLastConversionResults() {
 */
 /**************************************************************************/
 float Adafruit_ADS1X15::computeVolts(int16_t counts) {
-  // see data sheet Table 3
-  float fsRange;
-  switch (m_gain) {
-  case GAIN_TWOTHIRDS:
-    fsRange = 6.144f;
-    break;
-  case GAIN_ONE:
-    fsRange = 4.096f;
-    break;
-  case GAIN_TWO:
-    fsRange = 2.048f;
-    break;
-  case GAIN_FOUR:
-    fsRange = 1.024f;
-    break;
-  case GAIN_EIGHT:
-    fsRange = 0.512f;
-    break;
-  case GAIN_SIXTEEN:
-    fsRange = 0.256f;
-    break;
-  default:
-    fsRange = 0.0f;
-  }
-  return counts * (fsRange / (32768 >> m_bitShift));
+  return counts * (getFsRange() / (32768 >> m_bitShift));
 }
 
 /**************************************************************************/

--- a/Adafruit_ADS1X15.h
+++ b/Adafruit_ADS1X15.h
@@ -162,6 +162,7 @@ public:
   int16_t readADC_Differential_2_3();
   void startComparator_SingleEnded(uint8_t channel, int16_t threshold);
   int16_t getLastConversionResults();
+  float getFsRange();
   float computeVolts(int16_t counts);
   void setGain(adsGain_t gain);
   adsGain_t getGain();

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,6 +6,7 @@ readADC_Differential_0_1	KEYWORD2
 readADC_Differential_2_3	KEYWORD2
 startComparator_SingleEnded	KEYWORD2
 getLastConversionResults	KEYWORD2
+getFsRange	KEYWORD1
 computeVolts	KEYWORD2
 setGain	KEYWORD2
 getGain	KEYWORD2


### PR DESCRIPTION
Abstract and expose `getFsRange()`, which may be used by users of the class to understand what the actual voltage range is for the specified gain without having to maintain a separate mapping. No functional changes are expected.
